### PR TITLE
refactor: sm-50 - add active ring effect, update size variants 

### DIFF
--- a/src/components/Button/index.style.tsx
+++ b/src/components/Button/index.style.tsx
@@ -10,25 +10,26 @@ export const buttonStyles = cva(
     "disabled:cursor-not-allowed",
     "flex",
     "items-center",
+    "justify-center",
     "gap-3",
   ],
   {
     variants: {
       variant: {
         solid:
-          "dark:bg-secondary dark:hover:bg-secondary/90 dark:text-primary bg-primary hover:bg-primary/90  text-white",
+          "dark:bg-secondary dark:hover:bg-secondary/90 dark:active:ring-2 dark:active:ring-secondary/50 dark:text-primary bg-primary hover:bg-primary/90 active:ring-2 active:ring-primary/50 text-white",
         outline:
-          "dark:border-secondary dark:text-secondary dark:hover:bg-secondary/10 border-primary bg-transparent hover:bg-primary/10 border-2",
+          "dark:border-secondary dark:text-secondary dark:hover:bg-secondary/10 dark:active:ring-2 dark:active:ring-secondary/50 border-primary bg-transparent hover:bg-primary/10 active:ring-2 active:ring-primary/50 border-2",
         ghost:
-          "dark:text-secondary dark:hover:bg-secondary/10 transition-colors duration-300  hover:bg-primary/10",
+          "dark:text-secondary dark:hover:bg-secondary/10 dark:active:ring-2 dark:active:ring-secondary/50 transition-colors duration-300 hover:bg-primary/10 active:ring-2 active:ring-primary/50",
         link: "dark:text-secondary bg-transparent underline-offset-4 hover:underline cursor-pointer",
-        destructive: "bg-red-600 hover:bg-red-700/90 text-white",
+        destructive: "bg-red-600 hover:bg-red-700/90 active:ring-2 active:ring-red-300 text-white",
       },
       size: {
-        sm: "px-4 py-2 text-sm",
-        md: "px-4 py-2 text-base",
-        lg: "px-6 py-3 text-lg",
-        icon: "p-2",
+        sm: "h-9 px-4 py-2 text-sm",
+        md: "h-10 px-4 py-2 text-base",
+        lg: "h-11 px-6 py-3 text-lg",
+        icon: "h-8 w-8",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
- Introduced `active:ring-2` and `dark:active:ring-2` classes to all button variants for a consistent ring effect on the active state.
- Update text alignment to `justify-center` for 
- Updated size variants with specific height (`h-`) classes for consistent button height:
  - `sm`: `h-9`
  - `md`: `h-10`
  - `lg`: `h-11`
  - `icon`: `h-8 w-8`
