### PR TITLE
sm-56 - create skeleton component

### DIFF
--- a/src/components/Button/index.style.tsx
+++ b/src/components/Button/index.style.tsx
@@ -10,25 +10,26 @@ export const buttonStyles = cva(
     "disabled:cursor-not-allowed",
     "flex",
     "items-center",
+    "justify-center",
     "gap-3",
   ],
   {
     variants: {
       variant: {
         solid:
-          "dark:bg-secondary dark:hover:bg-secondary/90 dark:text-primary bg-primary hover:bg-primary/90  text-white",
+          "dark:bg-secondary dark:hover:bg-secondary/90 dark:active:ring-2 dark:active:ring-secondary/50 dark:text-primary bg-primary hover:bg-primary/90 active:ring-2 active:ring-primary/50 text-white",
         outline:
-          "dark:border-secondary dark:text-secondary dark:hover:bg-secondary/10 border-primary bg-transparent hover:bg-primary/10 border-2",
+          "dark:border-secondary dark:text-secondary dark:hover:bg-secondary/10 dark:active:ring-2 dark:active:ring-secondary/50 border-primary bg-transparent hover:bg-primary/10 active:ring-2 active:ring-primary/50 border-2",
         ghost:
-          "dark:text-secondary dark:hover:bg-secondary/10 transition-colors duration-300  hover:bg-primary/10",
+          "dark:text-secondary dark:hover:bg-secondary/10 dark:active:ring-2 dark:active:ring-secondary/50 transition-colors duration-300 hover:bg-primary/10 active:ring-2 active:ring-primary/50",
         link: "dark:text-secondary bg-transparent underline-offset-4 hover:underline cursor-pointer",
-        destructive: "bg-red-600 hover:bg-red-700/90 text-white",
+        destructive: "bg-red-600 hover:bg-red-700/90 active:ring-2 active:ring-red-300 text-white",
       },
       size: {
-        sm: "px-4 py-2 text-sm",
-        md: "px-4 py-2 text-base",
-        lg: "px-6 py-3 text-lg",
-        icon: "p-2",
+        sm: "h-9 px-4 py-2 text-sm",
+        md: "h-10 px-4 py-2 text-base",
+        lg: "h-11 px-6 py-3 text-lg",
+        icon: "h-8 w-8",
       },
     },
     defaultVariants: {

--- a/src/components/Skeleton/index.stories.tsx
+++ b/src/components/Skeleton/index.stories.tsx
@@ -1,0 +1,98 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Skeleton } from ".";
+
+const meta: Meta = {
+  title: "Components/Skeleton",
+  component: Skeleton,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      options: ["circular", "rectangular", "text"],
+      control: { type: "select" },
+    },
+    width: {
+      control: { type: "text" },
+    },
+    height: {
+      control: { type: "text" },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Circular: Story = {
+  args: {
+    variant: "circular",
+  },
+};
+
+export const Rectangular: Story = {
+  args: {
+    variant: "rectangular",
+  },
+};
+export const Text: Story = {
+  args: {
+    variant: "text",
+  },
+};
+
+const UserProfileSkeleton = () => (
+  <div className="flex gap-2 items-center">
+    <Skeleton variant="circular" width="40px" height="40px" />
+    <div className="flex flex-col gap-2 justify-center">
+      <Skeleton variant="text" width="150px" />
+      <Skeleton variant="text" width="100px" />
+    </div>
+  </div>
+);
+
+const ActionIconsSkeleton = () => (
+  <div className="flex gap-2 justify-end items-center">
+    <Skeleton width="40px" height="40px" />
+    <Skeleton width="40px" height="40px" />
+  </div>
+);
+
+export const Example1: Story = {
+  argTypes: {
+    variant: {
+      control: false,
+    },
+    width: {
+      control: false,
+    },
+    height: {
+      control: false,
+    },
+  },
+  render: () => (
+    <div className="w-[500px] grid grid-cols-2 bg-gray-100 dark:bg-gray-800 p-4">
+      <UserProfileSkeleton />
+      <ActionIconsSkeleton />
+    </div>
+  ),
+};
+
+export const Example2: Story = {
+  argTypes: {
+    variant: {
+      control: false,
+    },
+    width: {
+      control: false,
+    },
+    height: {
+      control: false,
+    },
+  },
+  render: () => (
+    <div className="w-[600px] bg-gray-100 dark:bg-gray-800 p-4 space-y-2">
+      <UserProfileSkeleton />
+      <Skeleton variant="rectangular" height="200px" />
+    </div>
+  ),
+};

--- a/src/components/Skeleton/index.style.tsx
+++ b/src/components/Skeleton/index.style.tsx
@@ -1,0 +1,14 @@
+import { cva } from "class-variance-authority";
+
+export const skeletonStyle = cva(["animate-pulse", "bg-primary/30", "dark:bg-secondary/30"], {
+  variants: {
+    variant: {
+      circular: "rounded-full h-10 w-10",
+      rectangular: "rounded-sm w-full min-h-4",
+      text: "text-base rounded-lg h-2 w-full",
+    },
+  },
+  defaultVariants: {
+    variant: "circular",
+  },
+});

--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/utils";
+import { VariantProps } from "class-variance-authority";
+import { ComponentProps } from "react";
+import { skeletonStyle } from "./index.style";
+
+type SkeletonProps = ComponentProps<"div"> &
+  VariantProps<typeof skeletonStyle> & {
+    variant?: "circular" | "rectangular" | "text";
+    width?: string;
+    height?: string;
+  };
+
+export const Skeleton: React.FC<SkeletonProps> = ({
+  variant = "rectangular",
+  width,
+  height,
+  className,
+  ...props
+}) => {
+  return (
+    <div
+      className={cn(skeletonStyle({ variant }), className)}
+      style={{ width, height }}
+      aria-hidden={true}
+      {...props}
+    ></div>
+  );
+};

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,1 +1,2 @@
 export * from "./Button";
+export * from "./Skeleton";


### PR DESCRIPTION
This PR introduces a new **Skeleton component** designed to provide a placeholder loading state for content that is still being fetched or processed. The component aims to enhance the user experience by offering a visual indication that content is on its way.

- Variants:

  1. **Circular**: Ideal for avatars, profile pictures, or any other circular content placeholders.
  2. **Rectangular**: Suitable for cards, images, or content blocks that require a rectangular placeholder.
  3. **Text**: Mimics the appearance of text lines, perfect for loading states in articles, blogs, or any text-heavy content.

- Customization:

  - Support for different sizes
  
![image](https://github.com/user-attachments/assets/664c3382-bc77-451e-a580-cb7abd554a7b)
![image](https://github.com/user-attachments/assets/797cb43a-0637-4f95-8e3a-f4fa598b6e4c)
