### PR TITLE
fix: convert tooltip component to named export

### DIFF
--- a/src/components/Tooltip/index.stories.tsx
+++ b/src/components/Tooltip/index.stories.tsx
@@ -1,5 +1,6 @@
+import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import Tooltip from "./index";
+import { Tooltip } from "./index";
 import { Button } from "../Button";
 import { IoMdHome } from "react-icons/io";
 

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -23,7 +23,7 @@ export type TooltipProps = ComponentProps<"div"> &
       | "rightEnd";
   };
 
-const Tooltip: React.FC<TooltipProps> = ({
+export const Tooltip: React.FC<TooltipProps> = ({
   position = "top",
   content,
   className,
@@ -48,5 +48,3 @@ const Tooltip: React.FC<TooltipProps> = ({
     </>
   );
 };
-
-export default Tooltip;


### PR DESCRIPTION
convert tooltip component to named export